### PR TITLE
Fix 'fd_set' has not been declared error

### DIFF
--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -75,7 +75,8 @@
     defined(__minix) || defined(__SYMBIAN32__) || defined(__INTEGRITY) || \
     defined(ANDROID) || defined(__ANDROID__) || defined(__OpenBSD__) || \
     defined(__CYGWIN__) || \
-   (defined(__FreeBSD_version) && (__FreeBSD_version < 800000))
+   (defined(__FreeBSD_version) && (__FreeBSD_version < 800000)) || \
+   defined(__SWITCH__)
 #include <sys/select.h>
 #endif
 


### PR DESCRIPTION
Note: This is a copy-paste from the Pull Request at devkitpro/pacman-packages#222. Had to relocate since it wasn't clear where to make a Pull Request for switch-curl.

Without adding `#include <sys/select.h>` before including curl, any projects using switch-curl will fail to compile because of this error:
```
/opt/devkitpro/portlibs/switch/include/curl/multi.h:159:40: error: 'fd_set' has not been declared
  159 |                                        fd_set *read_fd_set,
      |                                        ^~~~~~
/opt/devkitpro/portlibs/switch/include/curl/multi.h:160:40: error: 'fd_set' has not been declared
  160 |                                        fd_set *write_fd_set,
      |                                        ^~~~~~
/opt/devkitpro/portlibs/switch/include/curl/multi.h:161:40: error: 'fd_set' has not been declared
  161 |                                        fd_set *exc_fd_set,
      |                                        ^~~~~~
```
This Pull Request fixes this error and means you don't have to include sys/select.h before including curl.